### PR TITLE
feat: 기본 인증 필터 추가

### DIFF
--- a/src/main/java/com/dayaeyak/gateway/constraints/HeaderConstraints.java
+++ b/src/main/java/com/dayaeyak/gateway/constraints/HeaderConstraints.java
@@ -1,0 +1,9 @@
+package com.dayaeyak.gateway.constraints;
+
+public class HeaderConstraints {
+
+    public final static String AUTHORIZATION_HEADER = "Authorization";
+    public final static String BEARER_PREFIX = "Bearer ";
+    public static final String USER_ID_HEADER = "X-User-Id";
+    public static final String USER_ROLE_HEADER = "X-User-Role";
+}

--- a/src/main/java/com/dayaeyak/gateway/dto/RequestUserInfo.java
+++ b/src/main/java/com/dayaeyak/gateway/dto/RequestUserInfo.java
@@ -1,0 +1,17 @@
+package com.dayaeyak.gateway.dto;
+
+import io.jsonwebtoken.Claims;
+
+public record RequestUserInfo(
+        String userId,
+
+        String role
+) {
+
+    public static RequestUserInfo from(Claims claims) {
+        return new RequestUserInfo(
+                claims.getSubject(),
+                claims.get("role", String.class)
+        );
+    }
+}

--- a/src/main/java/com/dayaeyak/gateway/filter/AuthenticationFilter.java
+++ b/src/main/java/com/dayaeyak/gateway/filter/AuthenticationFilter.java
@@ -1,0 +1,79 @@
+package com.dayaeyak.gateway.filter;
+
+import com.dayaeyak.gateway.constraints.HeaderConstraints;
+import com.dayaeyak.gateway.dto.RequestUserInfo;
+import com.dayaeyak.gateway.util.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.PathContainer;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.util.pattern.PathPattern;
+import org.springframework.web.util.pattern.PathPatternParser;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AuthenticationFilter implements GlobalFilter {
+
+    private final JwtProvider jwtProvider;
+
+    // white list
+    private final List<PathPattern> whiteList = List.of(
+            new PathPatternParser().parse("/auth/**")
+    );
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        ServerHttpRequest request = exchange.getRequest();
+        String path = request.getPath().value();
+
+        if (isWhiteListed(path)) {
+            return chain.filter(exchange);
+        }
+
+        String token = extractToken(request);
+
+        if (!StringUtils.hasText(token) || !jwtProvider.validateAccessToken(token)) {
+            log.warn("Invalid access token");
+            exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
+            return exchange.getResponse().setComplete();
+        }
+
+        RequestUserInfo userInfo = jwtProvider.getUserInfoFromToken(token);
+
+        return chain.filter(
+                exchange.mutate()
+                        .request(builder -> builder
+                                .headers(header -> {
+                                    header.set(HeaderConstraints.USER_ID_HEADER, userInfo.userId());
+                                    header.set(HeaderConstraints.USER_ROLE_HEADER, userInfo.role());
+                                })
+                        )
+                        .build()
+        );
+    }
+
+    private boolean isWhiteListed(String path) {
+        PathContainer pathContainer = PathContainer.parsePath(path);
+        return whiteList.stream().anyMatch(white -> white.matches(pathContainer));
+    }
+
+    private String extractToken(ServerHttpRequest request) {
+        String authHeader = request.getHeaders().getFirst(HeaderConstraints.AUTHORIZATION_HEADER);
+
+        if (authHeader != null && authHeader.startsWith(HeaderConstraints.BEARER_PREFIX)) {
+            return authHeader.substring(7);
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/dayaeyak/gateway/util/JwtProvider.java
+++ b/src/main/java/com/dayaeyak/gateway/util/JwtProvider.java
@@ -1,0 +1,59 @@
+package com.dayaeyak.gateway.util;
+
+import com.dayaeyak.gateway.dto.RequestUserInfo;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class JwtProvider {
+
+    private final SecretKey accessSecretKey;
+
+    public JwtProvider(
+            @Value("${jwt.access.key}") String accessKey
+    ) {
+        this.accessSecretKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(accessKey));
+    }
+
+    public boolean validateAccessToken(String token) {
+        try {
+            Claims claims = parseClaims(token, accessSecretKey);
+            return claims.getExpiration().after(new Date(System.currentTimeMillis()));
+        } catch (ExpiredJwtException e) {
+            log.warn("Expired JWT: {}", e.getMessage());
+        } catch (SignatureException e) {
+            log.warn("Invalid JWT signature: {}", e.getMessage());
+        } catch (MalformedJwtException e) {
+            log.warn("Malformed JWT: {}", e.getMessage());
+        } catch (UnsupportedJwtException e) {
+            log.warn("Unsupported JWT: {}", e.getMessage());
+        } catch (IllegalArgumentException e) {
+            log.warn("Empty or null JWT: {}", e.getMessage());
+        }
+
+        return false;
+    }
+
+    public RequestUserInfo getUserInfoFromToken(String token) {
+        Claims claims = parseClaims(token, accessSecretKey);
+
+        return RequestUserInfo.from(claims);
+    }
+
+    private Claims parseClaims(String token, SecretKey secretKey) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}


### PR DESCRIPTION
## 📝 요약(Summary)

JWT 인증 필터 추가

## 💫 구현 및 변경 사항 (Details)

일단 `/auth/**` 외 나머지 엔드포인트는 `accessToken`을 요구하도록 했습니다.

header
- 요청 유저 ID = key: `X-User-Id`
- 요청 유저 권한 = key: `X-User-Role`

## 📸스크린샷 (선택)

## ✅ 체크리스트

- [x] 코드 정상 작동 테스트 완료
- [x] 관련 문서(API 문서, 위키 등) 업데이트
- [x] 팀의 코드 컨벤션/스타일 가이드 준수
- [x] Reviewers에 팀원 등록


## 💬 TODO ( 미완성일 경우 )
- 기본적으로 필터에서 유저 조회하도록 구현할 생각이니 userId를 바로 사용하도록 구현 해주시면 될 것 같아요

## 기타/주의사항